### PR TITLE
Update Dockerfile

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16
+FROM node:16
 RUN yarn global add gatsby-cli gatsby gatsby-theme-carbon
 EXPOSE 8000
 WORKDIR /home


### PR DESCRIPTION
Boyscouting all the way! 🧹:) 

Latest gatsby fails to install with node version 14. Upgrade to 16

The build command `docker build -f scripts/Dockerfile -t eda-nodes-env .` fails:

```
76.58 npm ERR! Exit status 1
76.58 npm ERR! 
76.58 npm ERR! Failed at the sharp@0.32.6 install script.
76.58 npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
76.60 
76.60 npm ERR! A complete log of this run can be found in:
76.60 npm ERR!     /root/.npm/_logs/2024-03-18T08_33_48_661Z-debug.log
------
Dockerfile:3
--------------------
   1 |     FROM node:14.16
   2 |     RUN npm install -g gatsby-cli
   3 | >>> RUN npm install -g gatsby
   4 |     RUN npm install -g gatsby-theme-carbon
   5 |     EXPOSE 8000
--------------------
ERROR: failed to solve: process "/bin/sh -c npm install -g gatsby" did not complete successfully: exit code: 1
```

Upgrading to Node16 fixes the issue